### PR TITLE
Update versions of esprima and source-map

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ function generate(file) {
   };
 
   var map = new SourceMapGenerator(options);
-  var tokens = esprima.tokenize(file.source, { loc: true });
+  var code = file.source;
+  if (typeof code !== 'string' && !(code instanceof String)) {
+    code = String(code);
+  }
+  var tokens = esprima.tokenize(code, { loc: true });
 
   tokens.forEach(function(token) {
     var loc = token.loc.start;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Generates an identity source-map from a javascript file",
   "main": "index.js",
   "dependencies": {
-    "source-map": "~0.1.34",
-    "esprima": "~1.2.2"
+    "esprima": "^4.0.1",
+    "source-map": "^0.7.4"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This PR updates the version of esprima and source-map to generate sourceMaps for files that contain newer ECMAScript features.

To be backwards compatible to the example from the README, source is converted to string (esprima since version 3.0.0 no longer converts code parameter of tokenize function to string).

Resolves #2 